### PR TITLE
Fix stale docs and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CLAUDE.md
 scripts/DEMO_GUIDE.md
 scripts/seed_demo_db.py
 .DS_Store
+*.jsonl

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,7 @@
 
 **Decision:** Expose decisions to AI agents via MCP over stdio transport.
 
-**Reasoning:** MCP is the emerging standard for tool integration with AI coding agents. Claude Code and Cursor both support MCP natively. Using stdio transport means no HTTP server to manage — the agent spawns the MCP server as a subprocess. This gives agents 8 specialized tools (query_decisions, validate_approach, recall_learnings, etc.) instead of dumping all context into a static file. Alternatives considered: static CLAUDE.md file (no interactivity), HTTP API (requires running server), Language Server Protocol (wrong abstraction).
+**Reasoning:** MCP is the emerging standard for tool integration with AI coding agents. Claude Code and Cursor both support MCP natively. Using stdio transport means no HTTP server to manage — the agent spawns the MCP server as a subprocess. This gives agents 9 specialized tools (query_decisions, validate_approach, recall_learnings, etc.) instead of dumping all context into a static file. Alternatives considered: static CLAUDE.md file (no interactivity), HTTP API (requires running server), Language Server Protocol (wrong abstraction).
 
 **Alternatives rejected:** HTTP REST API, static context files only, Language Server Protocol
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Patrick Kilian
+Copyright (c) 2025-2026 Patrick Kilian
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Restart Claude Code after running `init`. It picks up `.mcp.json` automatically 
 - `validate_approach` — checks if a proposed implementation conflicts with existing decisions
 - `get_decisions_by_entity` — all decisions about a specific technology
 - `list_entities` — see all technologies/patterns that have decisions
+- `get_related_entities` — explore the entity graph (what depends on what)
 - `get_decision_context` — full project decision summary
 - `recall_learnings` — search past session learnings (bugs, gotchas, implementations)
 - `get_session_briefing` — catch up on recent learnings, recurring patterns, and new decisions at the start of a session
+- `get_context_for_file` — get decisions and learnings relevant to a specific file
 
 Session learnings are captured automatically at the end of each Claude Code session via hooks. No extra work needed.
 
@@ -150,6 +152,8 @@ Example output:
 | `setkontext stats` | Show extraction and learning statistics |
 | `setkontext generate` | Generate a static context file (includes learnings) |
 | `setkontext consolidate` | Promote recurring learnings into decisions (interactive) |
+| `setkontext dedup` | Find and merge duplicate decisions across sources |
+| `setkontext watch` | Watch for new merged PRs and extract decisions continuously |
 | `setkontext check` | Check recent PRs for decision drift |
 | `setkontext serve` | Start MCP server (called automatically by Claude Code) |
 
@@ -207,7 +211,6 @@ This is v0.1.0. Expect rough edges. Known limitations:
 - Only GitHub repositories (no GitLab/Bitbucket yet)
 - Automatic session capture hooks are configured for Claude Code (`SessionEnd` hook). Other agents can use `setkontext capture` by piping transcripts to stdin.
 - Extraction and queries use the Anthropic API — you need your own API key
-- No incremental extraction yet (re-running extract processes everything again, but merges results)
 
 ## Feedback
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,24 @@
 [project]
 name = "setkontext"
 version = "0.1.0"
-description = "Extract engineering decisions from GitHub PRs and ADRs for AI coding agents"
+description = "Decision memory for AI coding agents — extracts decisions from GitHub, captures session learnings, and consolidates patterns"
+readme = "README.md"
+license = "MIT"
 requires-python = ">=3.11"
+authors = [
+    { name = "Patrick Kilian" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Documentation",
+    "Topic :: Software Development :: Version Control :: Git",
+]
 dependencies = [
     "pygithub",
     "anthropic",
@@ -21,6 +37,11 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/patxkil/setkontext"
+Repository = "https://github.com/patxkil/setkontext"
+Issues = "https://github.com/patxkil/setkontext/issues"
 
 [project.scripts]
 setkontext = "setkontext.cli:app"


### PR DESCRIPTION
Update README (complete MCP tools list, add missing CLI commands, remove stale limitations), add pyproject.toml metadata (license, authors, classifiers, URLs), fix tool count in ARCHITECTURE.md, add *.jsonl to gitignore, update LICENSE copyright year.